### PR TITLE
Make sync_log default to true

### DIFF
--- a/kong/plugins/http-log-extended/schema.lua
+++ b/kong/plugins/http-log-extended/schema.lua
@@ -10,6 +10,6 @@ return {
     flush_timeout = { type = "number", default = 2 },
     log_request_body = { type = "boolean", default = true },
     log_response_body = { type = "boolean", default = true },
-    sync_log = { type = "boolean", default = false},
+    sync_log = { type = "boolean", default = true },
   }
 }


### PR DESCRIPTION
sync_log works better in terms of reducing the latency, I also checked the memory usage of Kong, looks good. So making this the default option.